### PR TITLE
gui: sdl: Ignore GLEW_ERROR_NO_GLX_DISPLAY during GLEW init

### DIFF
--- a/source/gui/sdl/video.c
+++ b/source/gui/sdl/video.c
@@ -23,6 +23,7 @@ void
 gui_sdl_video_init(
     struct app *app
 ) {
+    int err;
     SDL_DisplayMode mode;
     char const *glsl_version;
 
@@ -113,7 +114,7 @@ gui_sdl_video_init(
     SDL_GL_SetSwapInterval(app->video.vsync);
 
     /* Initialize OpenGL */
-    int err = glewInit();
+    err = glewInit();
 
     if (err != GLEW_OK && err != GLEW_ERROR_NO_GLX_DISPLAY) {
         logln(HS_ERROR, "Failed to initialize OpenGL.");

--- a/source/gui/sdl/video.c
+++ b/source/gui/sdl/video.c
@@ -113,7 +113,9 @@ gui_sdl_video_init(
     SDL_GL_SetSwapInterval(app->video.vsync);
 
     /* Initialize OpenGL */
-    if (glewInit()) {
+    int err = glewInit();
+
+    if (err != GLEW_OK && err != GLEW_ERROR_NO_GLX_DISPLAY) {
         logln(HS_ERROR, "Failed to initialize OpenGL.");
         exit(EXIT_FAILURE);
     }


### PR DESCRIPTION
This is required to run on Wayland.

See https://github.com/nigels-com/glew/issues/172 for reference.